### PR TITLE
fix: etcd无法正确被初始化

### DIFF
--- a/kfs/content/kfs/v1.18/install-master.md
+++ b/kfs/content/kfs/v1.18/install-master.md
@@ -108,7 +108,7 @@ ExecStart=/usr/local/bin/etcd \\
   --listen-client-urls https://${INTERNAL_IP}:2379,https://127.0.0.1:2379 \\
   --advertise-client-urls https://${INTERNAL_IP}:2379 \\
   --initial-cluster-token etcd-cluster-0 \\
-  --initial-cluster master-1=https://${INTERNAL_IP}:2380 \\
+  --initial-cluster ${ETCD_NAME}=https://${INTERNAL_IP}:2380 \\
   --initial-cluster-state new \\
   --data-dir=/var/lib/etcd
 Restart=on-failure


### PR DESCRIPTION
修复了 couldn't find local name in the initial cluster configuration 这个报错